### PR TITLE
LIVETRIBE-88 added Attributes.toMap()

### DIFF
--- a/core/src/main/java/org/livetribe/slp/Attributes.java
+++ b/core/src/main/java/org/livetribe/slp/Attributes.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
+
 /**
  * Attributes are a comma separated list of key-value pairs that describe a service.
  * <br />
@@ -105,6 +106,50 @@ public class Attributes
         }
 
         return result;
+    }
+
+    /**
+     * Return a deep copy of an <code>Attributes</code> object and returns it
+     * as a map.
+     *
+     * @param from the <code>Attributes</code> object whose contents are copied
+     * @return a map whose contents were copied from the <code>Attributes</code> object
+     */
+    public static Map<String, Object> toMap(Attributes from)
+    {
+        Map<String, Object> result = new HashMap<String, Object>(from.getSize());
+
+        for (Map.Entry<Tag, Value> entry : from.attributes.entrySet())
+        {
+            result.put(unescapeTag(entry.getKey().tag), deepCopy(entry.getValue().value));
+        }
+
+        return result;
+    }
+
+    private static Object deepCopy(Object object)
+    {
+        if (object instanceof Object[])
+        {
+            Object[] from = (Object[])object;
+            Object[] result = new Object[from.length];
+            for (int i = 0; i < from.length; i++)
+            {
+                result[i] = deepCopy(from[i]);
+            }
+            return result;
+        }
+        else if (object instanceof byte[])
+        {
+            byte[] from = (byte[])object;
+            byte[] result = new byte[from.length];
+            System.arraycopy(from, 0, result, 0, from.length);
+            return result;
+        }
+        else
+        {
+            return object;
+        }
     }
 
     /**
@@ -465,7 +510,7 @@ public class Attributes
     {
         TreeMap<Tag, Value> orderedAttributes = new TreeMap<Tag, Value>(attributes);
         StringBuilder result = new StringBuilder();
-        for (Iterator<Map.Entry<Tag, Value>> entries = orderedAttributes.entrySet().iterator(); entries.hasNext();)
+        for (Iterator<Map.Entry<Tag, Value>> entries = orderedAttributes.entrySet().iterator(); entries.hasNext(); )
         {
             Map.Entry<Tag, Value> mapEntry = entries.next();
             Tag tag = mapEntry.getKey();
@@ -513,7 +558,7 @@ public class Attributes
     {
         TreeMap<Tag, Value> orderedAttributes = new TreeMap<Tag, Value>(attributes);
         StringBuilder result = new StringBuilder();
-        for (Iterator<Tag> tags = orderedAttributes.keySet().iterator(); tags.hasNext();)
+        for (Iterator<Tag> tags = orderedAttributes.keySet().iterator(); tags.hasNext(); )
         {
             Tag tag = tags.next();
             result.append(tag.tag);
@@ -571,7 +616,7 @@ public class Attributes
         {
             for (Tag tagToRemove : that.attributes.keySet())
             {
-                for (Iterator<Tag> tags = result.attributes.keySet().iterator(); tags.hasNext();)
+                for (Iterator<Tag> tags = result.attributes.keySet().iterator(); tags.hasNext(); )
                 {
                     Tag tag = tags.next();
                     if (tagToRemove.matches(tag)) tags.remove();
@@ -603,7 +648,7 @@ public class Attributes
 
         for (Tag tagToRetain : that.attributes.keySet())
         {
-            for (Iterator<Tag> tags = attributes.keySet().iterator(); tags.hasNext();)
+            for (Iterator<Tag> tags = attributes.keySet().iterator(); tags.hasNext(); )
             {
                 Tag tag = tags.next();
                 if (tagToRetain.matches(tag))
@@ -985,6 +1030,7 @@ public class Attributes
 
     private static class Attribute
     {
+
         private final Tag tag;
         private final Value value;
 

--- a/core/src/test/java/org/livetribe/slp/AttributesTest.java
+++ b/core/src/test/java/org/livetribe/slp/AttributesTest.java
@@ -16,8 +16,10 @@
 package org.livetribe.slp;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import org.testng.annotations.Test;
+
 
 /**
  * @version $Rev$ $Date$
@@ -450,5 +452,32 @@ public class AttributesTest
         assert merged.containsTag("i");
 
         assert merged.containsTag("j");
+    }
+
+    @Test
+    public void testAsMap()
+    {
+        Attributes attributes = Attributes.from("(a=1),(b=true),(c=string),(d=\\FF\\00),e,(f=1,2,3),(g=foo,bar,cdr),(h=\\FF\\00,\\FF\\01,\\FF\\02),(i=true,false,true)");
+        Map<String, Object> map = Attributes.toMap(attributes);
+
+        assert map.size() == 9;
+        assert map.get("a").equals(1);
+        assert map.get("b").equals(true);
+        assert map.get("c").equals("string");
+        assert Arrays.equals((byte[])map.get("d"), new byte[]{0x00});
+        assert map.get("e") == null;
+        assert Arrays.equals((Object[])map.get("f"), new Object[]{1, 2, 3});
+        assert Arrays.equals((Object[])map.get("g"), new Object[]{"foo", "bar", "cdr"});
+        assert Arrays.equals((Object[])map.get("i"), new Object[]{true, false, true});
+
+        Object[] h = (Object[])map.get("h");
+        assert Arrays.equals((byte[])h[0], new byte[]{0x00});
+        assert Arrays.equals((byte[])h[1], new byte[]{0x01});
+        assert Arrays.equals((byte[])h[2], new byte[]{0x02});
+
+        ((Object[])map.get("g"))[2] = "ouch";
+
+        map = Attributes.toMap(attributes);
+        assert Arrays.equals((Object[])map.get("g"), new Object[]{"foo", "bar", "cdr"});
     }
 }

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -29,7 +29,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <paxExamVersion>1.2.3</paxExamVersion>
+        <paxExamVersion>2.3.1</paxExamVersion>
+        <paxRunnerVersion>1.7.6</paxRunnerVersion>
         <osgiVersion>4.2.0.200908310645</osgiVersion>
     </properties>
 
@@ -43,36 +44,57 @@
         <dependencies>
 
             <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.8.1</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.geronimo.specs</groupId>
+                <artifactId>geronimo-atinject_1.0_spec</artifactId>
+                <version>1.0</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.livetribe.slp</groupId>
                 <artifactId>livetribe-slp</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.5</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>org.ops4j.pax.exam</groupId>
-                <artifactId>pax-exam</artifactId>
+                <artifactId>pax-exam-junit4</artifactId>
                 <version>${paxExamVersion}</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.ops4j.pax.exam</groupId>
-                <artifactId>pax-exam-junit</artifactId>
+                <artifactId>pax-exam-container-paxrunner</artifactId>
                 <version>${paxExamVersion}</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.ops4j.pax.exam</groupId>
-                <artifactId>pax-exam-container-default</artifactId>
+                <artifactId>pax-exam-link-assembly</artifactId>
                 <version>${paxExamVersion}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam-testforge</artifactId>
+                <version>${paxExamVersion}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.runner</groupId>
+                <artifactId>pax-runner-no-jcl</artifactId>
+                <version>${paxRunnerVersion}</version>
                 <scope>test</scope>
             </dependency>
 
@@ -88,6 +110,13 @@
                 <artifactId>OSGi_R4_v4.2_cmpn_spec</artifactId>
                 <version>${osgiVersion}</version>
                 <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>1.6.1</version>
+                <scope>test</scope>
             </dependency>
 
         </dependencies>

--- a/osgi/tests/pom.xml
+++ b/osgi/tests/pom.xml
@@ -62,20 +62,38 @@
         </dependency>
 
         <dependency>
-            <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-atinject_1.0_spec</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-junit</artifactId>
+            <artifactId>pax-exam-junit4</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-container-default</artifactId>
+            <artifactId>pax-exam-container-paxrunner</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-link-assembly</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ops4j.pax.runner</groupId>
+            <artifactId>pax-runner-no-jcl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-testforge</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -89,6 +107,12 @@
             <groupId>org.papoose.osgi</groupId>
             <artifactId>OSGi_R4_v4.2_cmpn_spec</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/osgi/tests/src/test/java/org/livetribe/slp/osgi/tests/SlpBundleTest.java
+++ b/osgi/tests/src/test/java/org/livetribe/slp/osgi/tests/SlpBundleTest.java
@@ -16,6 +16,7 @@
  */
 package org.livetribe.slp.osgi.tests;
 
+import javax.inject.Inject;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Locale;
@@ -24,18 +25,20 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.livetribe.slp.settings.Keys.PORT_KEY;
 import static org.ops4j.pax.exam.CoreOptions.equinox;
 import static org.ops4j.pax.exam.CoreOptions.felix;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.knopflerfish;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
 import static org.ops4j.pax.exam.CoreOptions.provision;
-import org.ops4j.pax.exam.Inject;
 import static org.ops4j.pax.exam.MavenUtils.asInProject;
 import org.ops4j.pax.exam.Option;
-import static org.ops4j.pax.exam.container.def.PaxRunnerOptions.compendiumProfile;
 import org.ops4j.pax.exam.junit.Configuration;
+import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
+import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -56,7 +59,6 @@ import org.livetribe.slp.osgi.ServiceNotificationListenerServiceTracker;
 import org.livetribe.slp.sa.ServiceAgent;
 import org.livetribe.slp.sa.ServiceNotificationEvent;
 import org.livetribe.slp.sa.ServiceNotificationListener;
-import static org.livetribe.slp.settings.Keys.PORT_KEY;
 import org.livetribe.slp.settings.MapSettings;
 import org.livetribe.slp.settings.Settings;
 import org.livetribe.slp.ua.UserAgent;
@@ -66,6 +68,7 @@ import org.livetribe.slp.ua.UserAgent;
  * @version $Revision$ $Date$
  */
 @RunWith(JUnit4TestRunner.class)
+@ExamReactorStrategy(AllConfinedStagedReactorFactory.class)
 public class SlpBundleTest
 {
     @Inject
@@ -75,11 +78,11 @@ public class SlpBundleTest
     public static Option[] configure()
     {
         return options(
+                junitBundles(),
                 equinox(),
                 felix(),
                 knopflerfish(),
 //                papoose(),
-                compendiumProfile(),
                 provision(
                         mavenBundle().groupId("org.livetribe.slp").artifactId("livetribe-slp-osgi").version(asInProject())
                 )


### PR DESCRIPTION
Instead of a simple iterator I added a toMap() function witch deep copies the contents of the Attributes object.  This keeps the basic character of the Attributes object, it being unmodifiable.
